### PR TITLE
[TEIID-5634] remove the modules section so that samples are not built as part of release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ sudo: false
 before_install:
 - cp .travis.settings.xml $HOME/.m2/settings.xml
 install: true
-script: mvn install -Dmaven.javadoc.skip=true -B -V -q -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn 
-after_script: travis_wait 5 mvn --version
+script: mvn install -Dmaven.javadoc.skip=true -B -V -q -U -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn 
 deploy:
   provider: script
   script: "mvn -B -q -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DskipTests=true deploy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: java
 sudo: false
 before_install:
 - cp .travis.settings.xml $HOME/.m2/settings.xml
-install: true
-script: mvn install -Dmaven.javadoc.skip=true -B -V -q -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn 
+install: travis_wait 10 mvn -Dmaven.javadoc.skip=true -B -V -q -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn 
 deploy:
   provider: script
   script: "mvn -B -q -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DskipTests=true deploy"

--- a/pom.xml
+++ b/pom.xml
@@ -324,12 +324,4 @@
     </profile>
   </profiles>
 
-  <modules>
-    <module>starter</module>
-    <module>starter-test</module>
-    <module>data/rest</module>
-    <module>data/excel</module>
-    <module>odata</module>
-    <module>samples</module>
-  </modules>
 </project>

--- a/samples/odata/pom.xml
+++ b/samples/odata/pom.xml
@@ -68,6 +68,15 @@
 
     <build>
         <plugins>
+            <plugin>            
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <forkCount>1</forkCount>
+                        <reuseForks>false</reuseForks>
+                        <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+                    </configuration>                    
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>


### PR DESCRIPTION
removed the modules since release already defined its modules, these defaults caused the samples to be included in the release build.  Also, a default profile is already defined that includes the samples, so these were redundant