### PR TITLE
[TEIIDSB-22] removed modules so that the defined modules for each profile is used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,13 +323,4 @@
       </build>
     </profile>
   </profiles>
-
-  <modules>
-    <module>starter</module>
-    <module>starter-test</module>
-    <module>data/rest</module>
-    <module>data/excel</module>
-    <module>odata</module>
-    <module>samples</module>
-  </modules>
 </project>


### PR DESCRIPTION
removed the modules since release already defined its modules, these defaults caused the samples to be included in the release build. Also, a default profile is already defined that includes the samples, so these were redundant