### PR TITLE
TEIIDSB-34: 

### DIFF
--- a/odata/src/main/java/org/teiid/spring/odata/AuthenticationInterceptor.java
+++ b/odata/src/main/java/org/teiid/spring/odata/AuthenticationInterceptor.java
@@ -20,6 +20,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
+import org.teiid.spring.autoconfigure.TeiidConstants;
 import org.teiid.spring.identity.SpringSecurityHelper;
 
 public class AuthenticationInterceptor implements HandlerInterceptor {
@@ -32,7 +33,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
             throws Exception {
-        this.securityHelper.authenticate("passthrough", "anonymous", null, null);
+        this.securityHelper.authenticate(TeiidConstants.SPRING_SECURITY, "anonymous", null, null);
         return true;
     }
 

--- a/odata/src/main/java/org/teiid/spring/odata/WebConfig.java
+++ b/odata/src/main/java/org/teiid/spring/odata/WebConfig.java
@@ -78,7 +78,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Bean
     SpringODataFilter getOdataFilter() {
-        return new SpringODataFilter(this.props, this.server, this.vdb, this.servletContext);
+        return new SpringODataFilter(this.props, this.server, this.vdb, this.servletContext, this.securityHelper);
     }
 
     @Bean
@@ -98,11 +98,11 @@ public class WebConfig implements WebMvcConfigurer {
 
         String[] excludes = exclude.toArray(new String[exclude.size()]);
 
-        registry.addInterceptor(getOdataFilter())
+        registry.addInterceptor(getAuthInterceptor())
         .addPathPatterns("/**")
         .excludePathPatterns(excludes);
 
-        registry.addInterceptor(getAuthInterceptor())
+        registry.addInterceptor(getOdataFilter())
         .addPathPatterns("/**")
         .excludePathPatterns(excludes);
     }

--- a/starter/src/main/java/org/teiid/spring/autoconfigure/TeiidAutoConfiguration.java
+++ b/starter/src/main/java/org/teiid/spring/autoconfigure/TeiidAutoConfiguration.java
@@ -265,6 +265,7 @@ public class TeiidAutoConfiguration implements Ordered {
         }
 
         if (embeddedConfiguration.getSecurityHelper() == null) {
+            embeddedConfiguration.setSecurityDomain(TeiidConstants.SPRING_SECURITY);
             embeddedConfiguration.setSecurityHelper(securityHelper);
         }
 

--- a/starter/src/main/java/org/teiid/spring/identity/TeiidSecurityContext.java
+++ b/starter/src/main/java/org/teiid/spring/identity/TeiidSecurityContext.java
@@ -13,19 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.teiid.spring.identity;
 
-package org.teiid.spring.autoconfigure;
+import javax.security.auth.Subject;
 
-public interface TeiidConstants {
+public class TeiidSecurityContext {
+    private Subject subject;
+    private String securityDomain;
+    private String userName;
 
-    String ENTITY_SCAN_DIR = "spring.teiid.model.package";
-    String REDIRECTED = "spring.teiid.redirected";
+    public String getUserName() {
+        return userName;
+    }
 
-    String REDIRECTED_TABLE_POSTFIX = "_REDIRECTED";
+    public TeiidSecurityContext(Subject s, String user, String securityDomain) {
+        this.subject = s;
+        this.userName = user;
+        this.securityDomain = securityDomain;
+    }
 
-    String SPRING_SECURITY = "spring-security";
+    public Subject getSubject() {
+        return subject;
+    }
 
-    String VDBNAME = "spring";
-    String VDBVERSION = "1.0.0";
-    String EXPOSED_VIEW = "teiid";
+    public String getSecurityDomain() {
+        return securityDomain;
+    }
 }


### PR DESCRIPTION
There were more than few things that were wrong in the previous commit.
* The security-context was being created, but wrongfully assumed it was being associated with the current thread during the 'createSession' call.
* Subject with Role names was being built wrong order than Teiid expects. Fixed that.
* Since we are using "spring-security", give the security help a new security-domain name and use that elsewhere such that that will be used. Note that, in the container world, since we are using single VDB per container VDB level security domain is not workable. Maybe we should ignore this during the migration of the .vdb to .DDL if one is set.
* Also using correct baseName if security-context is available during the Teiid's createSession call. 
* The authentication order in Web Interceptors was wrong. The auth filter needs to come before the odata filter.

