### PR TITLE
pg/jdbc username/password authentication

### DIFF
--- a/keycloak-db/pom.xml
+++ b/keycloak-db/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (C) 2016 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.teiid</groupId>
+    <artifactId>teiid-spring-boot-starter-parent</artifactId>
+    <version>1.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>spring-keycloak-db</artifactId>
+  <name>spring-keycloak-db</name>
+  <description>Expose DB (pg/jdbc) interface and Secure using Keycloak</description>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-spring-boot-starter</artifactId>
+    </dependency>    
+  </dependencies>
+</project>

--- a/keycloak-db/src/main/java/org/teiid/spring/db/security/KeycloakDirectAccessGrantAuthenticationProvider.java
+++ b/keycloak-db/src/main/java/org/teiid/spring/db/security/KeycloakDirectAccessGrantAuthenticationProvider.java
@@ -157,7 +157,8 @@ public class KeycloakDirectAccessGrantAuthenticationProvider extends KeycloakAut
         final Set<String> roles = AdapterUtils.getRolesFromSecurityContext(skSession);
         final KeycloakAccount account = new SimpleKeycloakAccount(principal, roles, skSession);
         KeycloakAuthenticationToken newAuth = new KeycloakAuthenticationToken(account, false);
-        return newAuth;
+        //call to the super logic to map authorities
+        return super.authenticate(newAuth);
     }
 
 }

--- a/keycloak-db/src/main/java/org/teiid/spring/db/security/KeycloakDirectAccessGrantAuthenticationProvider.java
+++ b/keycloak-db/src/main/java/org/teiid/spring/db/security/KeycloakDirectAccessGrantAuthenticationProvider.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2012- the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.teiid.spring.db.security;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.message.BasicNameValuePair;
+import org.jboss.logging.Logger;
+import org.keycloak.KeycloakPrincipal;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.adapters.AdapterUtils;
+import org.keycloak.adapters.KeycloakDeployment;
+import org.keycloak.adapters.RefreshableKeycloakSecurityContext;
+import org.keycloak.adapters.authentication.ClientCredentialsProviderUtils;
+import org.keycloak.adapters.jaas.DirectAccessGrantsLoginModule;
+import org.keycloak.adapters.rotation.AdapterTokenVerifier;
+import org.keycloak.adapters.spi.KeycloakAccount;
+import org.keycloak.adapters.springboot.KeycloakSpringBootConfigResolver;
+import org.keycloak.adapters.springsecurity.KeycloakAuthenticationException;
+import org.keycloak.adapters.springsecurity.account.SimpleKeycloakAccount;
+import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider;
+import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
+import org.keycloak.common.VerificationException;
+import org.keycloak.common.util.KeycloakUriBuilder;
+import org.keycloak.constants.ServiceUrlConstants;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.AccessTokenResponse;
+import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
+import org.keycloak.util.JsonSerialization;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+
+public class KeycloakDirectAccessGrantAuthenticationProvider extends KeycloakAuthenticationProvider {
+
+    private static final Logger log = Logger.getLogger(DirectAccessGrantsLoginModule.class);
+
+    private KeycloakSpringBootConfigResolver resolver;
+    private KeycloakDeployment deployment;
+    private String scope;
+
+    public KeycloakDirectAccessGrantAuthenticationProvider(
+            KeycloakSpringBootConfigResolver keycloakSpringBootConfigResolver) {
+        this.resolver = keycloakSpringBootConfigResolver;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        if (deployment == null) {
+            deployment = resolver.resolve(null);
+        }
+        UsernamePasswordAuthenticationToken token = (UsernamePasswordAuthenticationToken) authentication;
+        if (token.getCredentials() == null) {
+            throw new AuthenticationCredentialsNotFoundException("");
+        }
+        try {
+            return directGrantAuth(token.getName(), token.getCredentials().toString());
+        } catch (VerificationException|IOException e) {
+            throw new KeycloakAuthenticationException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * @see DirectAccessGrantsLoginModule
+     * @param username
+     * @param password
+     * @return
+     * @throws IOException
+     * @throws VerificationException
+     */
+    protected Authentication directGrantAuth(String username, String password) throws IOException, VerificationException {
+        String authServerBaseUrl = deployment.getAuthServerBaseUrl();
+        URI directGrantUri = KeycloakUriBuilder.fromUri(authServerBaseUrl).path(ServiceUrlConstants.TOKEN_PATH).build(deployment.getRealm());
+        HttpPost post = new HttpPost(directGrantUri);
+
+        List<NameValuePair> formparams = new ArrayList<NameValuePair>();
+        formparams.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, OAuth2Constants.PASSWORD));
+        formparams.add(new BasicNameValuePair("username", username));
+        formparams.add(new BasicNameValuePair("password", password));
+
+        if (scope != null) {
+            formparams.add(new BasicNameValuePair(OAuth2Constants.SCOPE, scope));
+        }
+
+        ClientCredentialsProviderUtils.setClientCredentials(deployment, post, formparams);
+
+        UrlEncodedFormEntity form = new UrlEncodedFormEntity(formparams, "UTF-8");
+        post.setEntity(form);
+
+        HttpClient client = deployment.getClient();
+        HttpResponse response = client.execute(post);
+        int status = response.getStatusLine().getStatusCode();
+        HttpEntity entity = response.getEntity();
+        if (status != 200) {
+            StringBuilder errorBuilder = new StringBuilder("Login failed. Invalid status: " + status);
+            if (entity != null) {
+                InputStream is = entity.getContent();
+                OAuth2ErrorRepresentation errorRep = JsonSerialization.readValue(is, OAuth2ErrorRepresentation.class);
+                errorBuilder.append(", OAuth2 error. Error: " + errorRep.getError())
+                        .append(", Error description: " + errorRep.getErrorDescription());
+            }
+            String error = errorBuilder.toString();
+            log.warn(error);
+            throw new IOException(error);
+        }
+
+        if (entity == null) {
+            throw new IOException("No Entity");
+        }
+
+        InputStream is = entity.getContent();
+        AccessTokenResponse tokenResponse = JsonSerialization.readValue(is, AccessTokenResponse.class);
+
+        AdapterTokenVerifier.VerifiedTokens tokens = AdapterTokenVerifier.verifyTokens(tokenResponse.getToken(), tokenResponse.getIdToken(), deployment);
+
+        return postTokenVerification(tokenResponse.getToken(), tokens.getAccessToken());
+    }
+
+    protected Authentication postTokenVerification(String tokenString, AccessToken token) {
+        RefreshableKeycloakSecurityContext skSession = new RefreshableKeycloakSecurityContext(deployment, null, tokenString, token, null, null, null);
+        String principalName = AdapterUtils.getPrincipalName(deployment, token);
+        final KeycloakPrincipal<RefreshableKeycloakSecurityContext> principal = new KeycloakPrincipal<RefreshableKeycloakSecurityContext>(principalName, skSession);
+        final Set<String> roles = AdapterUtils.getRolesFromSecurityContext(skSession);
+        final KeycloakAccount account = new SimpleKeycloakAccount(principal, roles, skSession);
+        KeycloakAuthenticationToken newAuth = new KeycloakAuthenticationToken(account, false);
+        return newAuth;
+    }
+
+}

--- a/keycloak-db/src/main/java/org/teiid/spring/db/security/SecurityConfig.java
+++ b/keycloak-db/src/main/java/org/teiid/spring/db/security/SecurityConfig.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2012- the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.teiid.spring.db.security;
+
+import org.keycloak.adapters.springboot.KeycloakSpringBootConfigResolver;
+import org.keycloak.adapters.springsecurity.KeycloakSecurityComponents;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.BeanIds;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.authentication.configuration.EnableGlobalAuthentication;
+
+@Configuration
+@EnableGlobalAuthentication
+@ComponentScan(basePackageClasses = KeycloakSecurityComponents.class)
+@PropertySource("classpath:keycloak.properties")
+@Order(99)
+public class SecurityConfig {
+
+    private AuthenticationConfiguration authenticationConfiguration;
+
+    @Autowired
+    public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
+        KeycloakDirectAccessGrantAuthenticationProvider authProvider = new KeycloakDirectAccessGrantAuthenticationProvider(
+                new KeycloakSpringBootConfigResolver());
+        auth.authenticationProvider(authProvider);
+    }
+
+    @Autowired
+    public void setAuthenticationConfiguration(
+            AuthenticationConfiguration authenticationConfiguration) {
+        this.authenticationConfiguration = authenticationConfiguration;
+    }
+
+    @Bean(name = BeanIds.AUTHENTICATION_MANAGER)
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+}

--- a/keycloak-db/src/main/java/org/teiid/spring/db/security/SecurityConfig.java
+++ b/keycloak-db/src/main/java/org/teiid/spring/db/security/SecurityConfig.java
@@ -28,6 +28,7 @@ import org.springframework.security.config.BeanIds;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.authentication.configuration.EnableGlobalAuthentication;
+import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
 
 @Configuration
 @EnableGlobalAuthentication
@@ -42,6 +43,7 @@ public class SecurityConfig {
     public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
         KeycloakDirectAccessGrantAuthenticationProvider authProvider = new KeycloakDirectAccessGrantAuthenticationProvider(
                 new KeycloakSpringBootConfigResolver());
+        authProvider.setGrantedAuthoritiesMapper(new SimpleAuthorityMapper());
         auth.authenticationProvider(authProvider);
     }
 

--- a/keycloak-db/src/main/resources/META-INF/spring.factories
+++ b/keycloak-db/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,4 @@
+# Configurations
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.teiid.spring.db.security.SecurityConfig
+
+# Listeners

--- a/keycloak-db/src/main/resources/META-INF/spring.provides
+++ b/keycloak-db/src/main/resources/META-INF/spring.provides
@@ -1,0 +1,1 @@
+provides: spring-security-core,spring-boot-starter-security

--- a/keycloak-db/src/main/resources/keycloak.properties
+++ b/keycloak-db/src/main/resources/keycloak.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# default keycloak properties, can be overridden
+keycloak.realm = master
+keycloak.ssl-required = external
+keycloak.public-client = true
+keycloak.principal-attribute=preferred_username
+
+# without this there is an error same bean name
+spring.main.allow-bean-definition-overriding=true

--- a/keycloak-odata/src/main/java/org/teiid/spring/odata/security/SecurityConfig.java
+++ b/keycloak-odata/src/main/java/org/teiid/spring/odata/security/SecurityConfig.java
@@ -24,28 +24,16 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.BeanIds;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
 import org.springframework.security.core.session.SessionRegistryImpl;
-/*
- * Copyright 2012-2017 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 
@@ -67,7 +55,7 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
     }
 
     @Bean
-    public KeycloakSpringBootConfigResolver KeycloakConfigResolver() {
+    public KeycloakSpringBootConfigResolver keycloakConfigResolver() {
         return new KeycloakSpringBootConfigResolver();
     }
 
@@ -75,6 +63,13 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
     @Override
     protected SessionAuthenticationStrategy sessionAuthenticationStrategy() {
         return new RegisterSessionAuthenticationStrategy(new SessionRegistryImpl());
+    }
+
+    @Bean(name = BeanIds.AUTHENTICATION_MANAGER)
+    @Primary
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
     }
 
     @Override
@@ -87,4 +82,5 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
         .antMatchers("/openapi.json").permitAll()
         .anyRequest().hasRole(odataRole);
     }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -418,6 +418,11 @@
       </dependency>
       <dependency>
         <groupId>org.teiid</groupId>
+        <artifactId>spring-keycloak-db</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.teiid</groupId>
         <artifactId>spring-data-rest</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -510,6 +515,7 @@
         <module>odata</module>
         <module>openapi</module>
         <module>keycloak-odata</module>
+        <module>keycloak-db</module>
         <module>samples</module>
       </modules>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -535,6 +535,7 @@
         <module>odata</module>
         <module>openapi</module>
         <module>keycloak-odata</module>
+        <module>keycloak-db</module>
       </modules>
       <build>
         <plugins>

--- a/starter/src/main/java/org/teiid/spring/autoconfigure/TeiidAutoConfiguration.java
+++ b/starter/src/main/java/org/teiid/spring/autoconfigure/TeiidAutoConfiguration.java
@@ -60,6 +60,7 @@ import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 import org.springframework.jdbc.datasource.embedded.ConnectionProperties;
 import org.springframework.jdbc.datasource.embedded.DataSourceFactory;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseFactory;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.teiid.adminapi.impl.VDBMetaData;
 import org.teiid.adminapi.impl.VDBMetadataParser;
 import org.teiid.cache.Cache;

--- a/starter/src/main/java/org/teiid/spring/autoconfigure/TeiidPostProcessor.java
+++ b/starter/src/main/java/org/teiid/spring/autoconfigure/TeiidPostProcessor.java
@@ -36,10 +36,12 @@ import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.core.Ordered;
 import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.teiid.PreParser;
 import org.teiid.adminapi.impl.VDBMetaData;
 import org.teiid.spring.data.BaseConnectionFactory;
+import org.teiid.spring.identity.SpringSecurityHelper;
 import org.teiid.translator.ExecutionFactory;
 
 /**
@@ -122,6 +124,11 @@ class TeiidPostProcessor implements BeanPostProcessor, Ordered, ApplicationListe
         } else if (bean instanceof PreParser) {
             TeiidServer server = this.beanFactory.getBean(TeiidServer.class);
             server.setPreParser((PreParser)bean);
+        } else if (bean instanceof AuthenticationManager) {
+            SpringSecurityHelper springSecurityHelper = this.beanFactory.getBean(SpringSecurityHelper.class);
+            if (springSecurityHelper != null) {
+                springSecurityHelper.setAuthenticationManager((AuthenticationManager)bean);
+            }
         }
         return bean;
     }

--- a/starter/src/main/java/org/teiid/spring/identity/TeiidSecurityContext.java
+++ b/starter/src/main/java/org/teiid/spring/identity/TeiidSecurityContext.java
@@ -17,19 +17,23 @@ package org.teiid.spring.identity;
 
 import javax.security.auth.Subject;
 
+import org.springframework.security.core.Authentication;
+
 public class TeiidSecurityContext {
     private Subject subject;
     private String securityDomain;
     private String userName;
+    private Authentication authentication;
 
     public String getUserName() {
         return userName;
     }
 
-    public TeiidSecurityContext(Subject s, String user, String securityDomain) {
+    public TeiidSecurityContext(Subject s, String user, String securityDomain, Authentication authentication) {
         this.subject = s;
         this.userName = user;
         this.securityDomain = securityDomain;
+        this.authentication = authentication;
     }
 
     public Subject getSubject() {
@@ -38,5 +42,9 @@ public class TeiidSecurityContext {
 
     public String getSecurityDomain() {
         return securityDomain;
+    }
+
+    public Authentication getAuthentication() {
+        return authentication;
     }
 }

--- a/starter/src/main/resources/teiid.properties
+++ b/starter/src/main/resources/teiid.properties
@@ -15,5 +15,5 @@
 #
 spring.datasource.type=org.apache.tomcat.jdbc.pool.DataSource
 spring.jpa.database-platform=org.teiid.dialect.TeiidDialect
-spring.datasource.teiid.url=jdbc:teiid:spring;useCallingThread=true;autoFailover=true;waitForLoad=5000;autoCommitTxn=OFF;disableLocalTxn=true
+spring.datasource.teiid.url=jdbc:teiid:spring;PassthroughAuthentication=true;useCallingThread=true;autoFailover=true;waitForLoad=5000;autoCommitTxn=OFF;disableLocalTxn=true
 #autoCommitTxn=OFF;disableLocalTxn=true


### PR DESCRIPTION
Here's the pr on the core side.  I'll follow-up with an expanded example.

I left a comment in here:
//TODO: need to discuss the spring role mapping ROLE_

Because I wanted to understand better what your thoughts are here.  Correct me if I'm wrong, but the idea is that there are built-in spring roles that start with ROLE_.  However we won't be utilizing those correct?  So should we be performing this mapping at all, only to undo it in the SpringSecurityHelper?  It's in this new code as well for consistency at the moment.  A concern would be that ROLE_x becomes a "reserved" naming convention.  If a keycloak user has either x or ROLE_x, they'll map to the same thing for us.  