### PR TITLE
Exclude jboss-logging from keycloak-spring-boot-starter to prevent alignment issues

### DIFF
--- a/keycloak/pom.xml
+++ b/keycloak/pom.xml
@@ -41,6 +41,10 @@
       <artifactId>keycloak-spring-boot-starter</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -429,6 +429,17 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-spring-boot-starter</artifactId>
+        <version>${version.org.keycloak}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+            </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.social</groupId>
         <artifactId>spring-social-core</artifactId>
         <version>${spring-social.version}</version>


### PR DESCRIPTION
Exclude jboss-logging from keycloak-spring-boot-starter to prevent alignment issues