### PR TITLE
TEIID-5920 - add exclusion because alignment doesn't apply override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,10 @@
             <groupId>javax.mail</groupId>
             <artifactId>mailapi</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+          </exclusion>
         </exclusions>        
       </dependency>
       <dependency>


### PR DESCRIPTION
TEIID-5920 - add exclusion because alignment doesn't apply override correctly to resolve conflicting versions