### PR TITLE
adding cassandra sample for spring boot

### DIFF
--- a/data/cassandra/pom.xml
+++ b/data/cassandra/pom.xml
@@ -60,6 +60,11 @@
         <artifactId>asm</artifactId>
         <version>5.0.4</version>
       </dependency>
+      <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-core</artifactId>
+        <version>3.2.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/samples/cassandra/pom.xml
+++ b/samples/cassandra/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>samples</artifactId>
         <groupId>org.teiid</groupId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -48,6 +48,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>5.0.4</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-core</artifactId>
+                <version>3.2.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>

--- a/samples/cassandra/pom.xml
+++ b/samples/cassandra/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (C) 2016 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>samples</artifactId>
+        <groupId>org.teiid</groupId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>spring-cassandra-example</artifactId>
+    <name>spring-cassandra-example</name>
+    <description>Demo project for Spring Boot show casing cassandra based</description>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.teiid</groupId>
+            <artifactId>teiid-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.teiid</groupId>
+            <artifactId>spring-data-cassandra</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/samples/cassandra/src/main/java/org/teiid/spring/example/Application.java
+++ b/samples/cassandra/src/main/java/org/teiid/spring/example/Application.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.teiid.spring.example;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+@SpringBootApplication
+public class Application implements CommandLineRunner {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args).close();
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        List<Map<String, Object>> list = jdbcTemplate.queryForList("SELECT *  FROM employee_by_id");
+        System.out.println(list);
+    }
+}

--- a/samples/cassandra/src/main/java/org/teiid/spring/example/DataSources.java
+++ b/samples/cassandra/src/main/java/org/teiid/spring/example/DataSources.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.teiid.spring.example;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.teiid.spring.data.cassandra.CassandraConfiguration;
+import org.teiid.spring.data.cassandra.CassandraConnectionFactory;
+
+@Configuration
+public class DataSources {
+
+    @Bean(name = "accounts")
+    public CassandraConnectionFactory accounts(@Qualifier("samplecassandra-config") CassandraConfiguration config) {
+        return new CassandraConnectionFactory(config);
+    }
+
+    @Bean(name = "samplecassandra-config")
+    @ConfigurationProperties("spring.teiid.data.cassandra")
+    public CassandraConfiguration config() { return new CassandraConfiguration(); }
+}

--- a/samples/cassandra/src/main/resources/application.properties
+++ b/samples/cassandra/src/main/resources/application.properties
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+spring.main.allow-bean-definition-overriding=true
+
 spring.teiid.data.cassandra.address = 127.0.0.1
 spring.teiid.data.cassandra.port=9042
 spring.teiid.data.cassandra.keyspace=test

--- a/samples/cassandra/src/main/resources/application.properties
+++ b/samples/cassandra/src/main/resources/application.properties
@@ -1,0 +1,25 @@
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+spring.teiid.data.cassandra.address = 127.0.0.1
+spring.teiid.data.cassandra.port=9042
+spring.teiid.data.cassandra.keyspace=test
+spring.teiid.data.cassandra.username=cassandra
+spring.teiid.data.cassandra.password=cassandra
+
+spring.teiid.model.package=org.teiid.spring.example
+
+logging.level.org.teiid.spring=DEBUG

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -72,6 +72,7 @@
     <module>openapi-consume</module>
     <module>soap</module>
     <module>ftp</module>
+    <module>cassandra</module>
   </modules>
 
 </project>


### PR DESCRIPTION
Facing an error. Logs:

15391 --- [           main] org.teiid.spring.example.Application     : Starting Application on aditya-Inspiron-5570 with PID 15391 (/home/aditya/Desktop/Teiid/teiid-spring-boot/samples/cassandra/target/classes started by aditya in /home/aditya/Desktop/Teiid/teiid-spring-boot)
2020-05-21 14:04:06.330 DEBUG 15391 --- [           main] org.teiid.spring.example.Application     : Running with Spring Boot v2.2.6.RELEASE, Spring v5.2.5.RELEASE
2020-05-21 14:04:06.332  INFO 15391 --- [           main] org.teiid.spring.example.Application     : No active profile set, falling back to default profiles: default
2020-05-21 14:04:10.000  INFO 15391 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JPA repositories in DEFAULT mode.
2020-05-21 14:04:10.059  INFO 15391 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 42ms. Found 0 JPA repository interfaces.
2020-05-21 14:04:11.073  INFO 15391 --- [           main] o.t.s.a.TeiidBeanDefinitionPostProcessor : Found data sources: []
2020-05-21 14:04:11.949  INFO 15391 --- [           main] trationDelegate$BeanPostProcessorChecker : Bean 'org.teiid.spring.autoconfigure.TransactionManagerConfiguration' of type [org.teiid.spring.autoconfigure.TransactionManagerConfiguration$$EnhancerBySpringCGLIB$$89cf0ae0] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
2020-05-21 14:04:12.041  INFO 15391 --- [           main] trationDelegate$BeanPostProcessorChecker : Bean 'platformTransactionManagerAdapter' of type [org.teiid.spring.autoconfigure.PlatformTransactionManagerAdapter] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
2020-05-21 14:04:12.365  INFO 15391 --- [           main] o.t.s.a.TeiidAutoConfiguration           : Starting Teiid Server.
2020-05-21 14:04:17.264  INFO 15391 --- [           main] org.teiid.RUNTIME.VDBLifeCycleListener   : TEIID40118 VDB spring.1.0.0 added to the repository
2020-05-21 14:04:17.273  INFO 15391 --- [           main] org.teiid.RUNTIME.VDBLifeCycleListener   : TEIID40003 VDB spring.1.0.0 is set to ACTIVE
2020-05-21 14:04:17.543  INFO 15391 --- [           main] o.s.j.d.e.EmbeddedDatabaseFactory        : Starting embedded database: url='jdbc:teiid:spring;PassthroughAuthentication=true;useCallingThread=true;autoFailover=true;waitForLoad=5000;autoCommitTxn=OFF;disableLocalTxn=true', username='null'
2020-05-21 14:04:19.233  INFO 15391 --- [           main] o.hibernate.jpa.internal.util.LogHelper  : HHH000204: Processing PersistenceUnitInfo [name: default]
2020-05-21 14:04:19.687  INFO 15391 --- [           main] org.hibernate.Version                    : HHH000412: Hibernate ORM core version 5.4.12.Final
2020-05-21 14:04:21.212  INFO 15391 --- [           main] o.hibernate.annotations.common.Version   : HCANN000001: Hibernate Commons Annotations {5.1.0.Final}
2020-05-21 14:04:21.477  INFO 15391 --- [           main] org.hibernate.dialect.Dialect            : HHH000400: Using dialect: org.teiid.dialect.TeiidDialect
2020-05-21 14:04:22.397  INFO 15391 --- [           main] o.h.e.t.j.p.i.JtaPlatformInitiator       : HHH000490: Using JtaPlatform implementation: [org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform]
2020-05-21 14:04:22.422  INFO 15391 --- [           main] j.LocalContainerEntityManagerFactoryBean : Initialized JPA EntityManagerFactory for persistence unit 'default'
2020-05-21 14:04:23.104  INFO 15391 --- [           main] o.t.spring.autoconfigure.TeiidServer     : Added accounts to the Teiid Database
2020-05-21 14:04:23.105  INFO 15391 --- [           main] org.teiid.RUNTIME.VDBLifeCycleListener   : TEIID40120 VDB spring.1.0.0 will be removed from the repository
2020-05-21 14:04:23.105  INFO 15391 --- [           main] org.teiid.RUNTIME.VDBLifeCycleListener   : TEIID40119 VDB spring.1.0.0 removed from the repository
2020-05-21 14:04:23.152  INFO 15391 --- [           main] org.teiid.RUNTIME.VDBLifeCycleListener   : TEIID40118 VDB spring.1.0.0 added to the repository
2020-05-21 14:04:23.174  INFO 15391 --- [           main] org.teiid.RUNTIME                        : TEIID50029 VDB spring.1.0.0 model "accounts" metadata is currently being loaded. Start Time: 21/5/20 2:04 PM
2020-05-21 14:04:23.351  INFO 15391 --- [           main] com.datastax.driver.core                 : DataStax Java driver 3.7.2 for Apache Cassandra
2020-05-21 14:04:23.473  INFO 15391 --- [           main] c.d.driver.core.GuavaCompatibility       : Detected Guava >= 19 in the classpath, using modern compatibility layer
2020-05-21 14:04:25.315  INFO 15391 --- [           main] com.datastax.driver.core.ClockFactory    : Using native clock to generate timestamps.
2020-05-21 14:04:25.972  INFO 15391 --- [           main] com.datastax.driver.core.NettyUtil       : Found Netty's native epoll transport in the classpath, using it
2020-05-21 14:04:26.250  WARN 15391 --- [           main] org.teiid.RUNTIME                        : TEIID50036 VDB spring.1.0.0 model "accounts" metadata failed to load. Reason:TEIID31178 Could not obtain connection for schema accounts, but one is required for metadata load.