### PR TITLE
Reusable connection

### DIFF
--- a/data/salesforce/src/main/java/org/teiid/spring/data/salesforce/SalesforceConnectionFactory.java
+++ b/data/salesforce/src/main/java/org/teiid/spring/data/salesforce/SalesforceConnectionFactory.java
@@ -63,7 +63,7 @@ public class SalesforceConnectionFactory implements BaseConnectionFactory<Salesf
 
         }
     }
-    
+
     @Override
     public SalesforceConnectionImpl getConnection() throws Exception {
         SalesforceConnectionImpl localInstance = connection;

--- a/data/salesforce/src/main/java/org/teiid/spring/data/salesforce/SalesforceConnectionImpl.java
+++ b/data/salesforce/src/main/java/org/teiid/spring/data/salesforce/SalesforceConnectionImpl.java
@@ -66,7 +66,7 @@ public class SalesforceConnectionImpl extends BaseSalesforceConnection<Salesforc
 
     @Override
     public boolean isValid() {
-        if (getPartnerConnection().isAccessTokenValid()) {
+        if (!getPartnerConnection().isAccessTokenValid()) {
             return false;
         }
         return super.isValid();


### PR DESCRIPTION
1. Added "reused connection". Old solution with new connection every request it is really not working on real cases because give very low performance.
2. Salesforce have some restrictions about multiple connections from one user in same jvm, so really we do not need connections poll in really cases.
3. This solution bit tested in experimental server with benchmark.
4. Fixed bug in connection validation.
