### PR TITLE
Bugfix invalid accesstoken

### DIFF
--- a/data/rest/src/main/java/org/teiid/spring/data/rest/RestConnectionFactory.java
+++ b/data/rest/src/main/java/org/teiid/spring/data/rest/RestConnectionFactory.java
@@ -134,7 +134,7 @@ public class RestConnectionFactory implements BaseConnectionFactory<RestConnecti
             return false;
         }
         if (this.accessGrant.getExpireTime() != null) {
-            return this.accessGrant.getExpireTime() < System.currentTimeMillis();
+            return this.accessGrant.getExpireTime() > System.currentTimeMillis();
         }
         return this.accessGrant.getAccessToken() != null;
     }


### PR DESCRIPTION
In org.springframework.social.oauth2.AccessGrant, the expireTime is calculated like this:
`this.expireTime = expiresIn != null ? System.currentTimeMillis() + expiresIn * 1000L : null;`

The current implementation always retrieves a new access token (well unless it actually expired, which is even worse).

Btw, why isn't the refresh token used to refresh the access token, using the OAuth 2.0 Refresh Token Grant?